### PR TITLE
Dispatch onActivityResult as part of ActivityLightCycle

### DIFF
--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/ActivityLightCycle.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/ActivityLightCycle.java
@@ -15,5 +15,6 @@ public interface ActivityLightCycle<T extends Activity> {
     void onStop(T activity);
     void onSaveInstanceState(T activity, Bundle bundle);
     void onRestoreInstanceState(T activity, Bundle bundle);
+    void onActivityResult(int requestCode, int resultCode, Intent data);
     void onDestroy(T activity);
 }

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/ActivityLightCycle.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/ActivityLightCycle.java
@@ -15,6 +15,6 @@ public interface ActivityLightCycle<T extends Activity> {
     void onStop(T activity);
     void onSaveInstanceState(T activity, Bundle bundle);
     void onRestoreInstanceState(T activity, Bundle bundle);
-    void onActivityResult(int requestCode, int resultCode, Intent data);
+    void onActivityResult(T activity, int requestCode, int resultCode, Intent data);
     void onDestroy(T activity);
 }

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/DefaultActivityLightCycle.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/DefaultActivityLightCycle.java
@@ -36,5 +36,8 @@ public class DefaultActivityLightCycle<T extends Activity> implements ActivityLi
     public void onRestoreInstanceState(T activity, Bundle bundle) { /* no-op */ }
 
     @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) { /* no-op */ }
+
+    @Override
     public void onDestroy(T activity) { /* no-op */ }
 }

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/DefaultActivityLightCycle.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/DefaultActivityLightCycle.java
@@ -36,7 +36,7 @@ public class DefaultActivityLightCycle<T extends Activity> implements ActivityLi
     public void onRestoreInstanceState(T activity, Bundle bundle) { /* no-op */ }
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) { /* no-op */ }
+    public void onActivityResult(T activity, int requestCode, int resultCode, Intent data) { /* no-op */ }
 
     @Override
     public void onDestroy(T activity) { /* no-op */ }

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/LightCycles.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/LightCycles.java
@@ -99,6 +99,11 @@ public final class LightCycles {
             }
 
             @Override
+            public void onActivityResult(int requestCode, int resultCode, Intent data) {
+                lightCycle.onActivityResult(requestCode, resultCode, data);
+            }
+
+            @Override
             public void onDestroy(Target activity) {
                 lightCycle.onDestroy(activity);
             }

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/LightCycles.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/LightCycles.java
@@ -99,8 +99,8 @@ public final class LightCycles {
             }
 
             @Override
-            public void onActivityResult(int requestCode, int resultCode, Intent data) {
-                lightCycle.onActivityResult(requestCode, resultCode, data);
+            public void onActivityResult(Target activity, int requestCode, int resultCode, Intent data) {
+                lightCycle.onActivityResult(activity, requestCode, resultCode, data);
             }
 
             @Override

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/ActivityLightCycleDispatcher.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/ActivityLightCycleDispatcher.java
@@ -90,9 +90,9 @@ public class ActivityLightCycleDispatcher<T extends Activity>
     }
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(T activity, int requestCode, int resultCode, Intent data) {
         for (ActivityLightCycle<T> component : activityLightCycles) {
-            component.onActivityResult(requestCode, resultCode, data);
+            component.onActivityResult(activity, requestCode, resultCode, data);
         }
     }
 

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/ActivityLightCycleDispatcher.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/ActivityLightCycleDispatcher.java
@@ -90,6 +90,13 @@ public class ActivityLightCycleDispatcher<T extends Activity>
     }
 
     @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        for (ActivityLightCycle<T> component : activityLightCycles) {
+            component.onActivityResult(requestCode, resultCode, data);
+        }
+    }
+
+    @Override
     public void onDestroy(T activity) {
         for (ActivityLightCycle<T> component : activityLightCycles) {
             component.onDestroy(activity);

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleActionBarActivity.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleActionBarActivity.java
@@ -79,6 +79,12 @@ public abstract class LightCycleActionBarActivity<ActivityType extends LightCycl
     }
 
     @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        lightCycleDispatcher.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
     protected void onDestroy() {
         lightCycleDispatcher.onDestroy(activity());
         super.onDestroy();

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleActionBarActivity.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleActionBarActivity.java
@@ -81,7 +81,7 @@ public abstract class LightCycleActionBarActivity<ActivityType extends LightCycl
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        lightCycleDispatcher.onActivityResult(requestCode, resultCode, data);
+        lightCycleDispatcher.onActivityResult(activity(), requestCode, resultCode, data);
     }
 
     @Override

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleAppCompatActivity.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleAppCompatActivity.java
@@ -80,7 +80,7 @@ public abstract class LightCycleAppCompatActivity<ActivityType extends LightCycl
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        lightCycleDispatcher.onActivityResult(requestCode, resultCode, data);
+        lightCycleDispatcher.onActivityResult(activity(), requestCode, resultCode, data);
     }
 
     @Override

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleAppCompatActivity.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleAppCompatActivity.java
@@ -78,6 +78,12 @@ public abstract class LightCycleAppCompatActivity<ActivityType extends LightCycl
     }
 
     @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        lightCycleDispatcher.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
     protected void onDestroy() {
         lightCycleDispatcher.onDestroy(activity());
         super.onDestroy();

--- a/lightcycle-lib/src/test/java/com/soundcloud/lightcycle/ActivityLightCycleDispatcherTest.java
+++ b/lightcycle-lib/src/test/java/com/soundcloud/lightcycle/ActivityLightCycleDispatcherTest.java
@@ -107,10 +107,10 @@ public class ActivityLightCycleDispatcherTest {
         int resultCode = 2;
         Intent data = new Intent();
 
-        dispatcher.onActivityResult(requestCode, resultCode, data);
+        dispatcher.onActivityResult(activity, requestCode, resultCode, data);
 
-        verify(lightCycleComponent1).onActivityResult(requestCode, resultCode, data);
-        verify(lightCycleComponent2).onActivityResult(requestCode, resultCode, data);
+        verify(lightCycleComponent1).onActivityResult(activity, requestCode, resultCode, data);
+        verify(lightCycleComponent2).onActivityResult(activity, requestCode, resultCode, data);
     }
 
     @Test

--- a/lightcycle-lib/src/test/java/com/soundcloud/lightcycle/ActivityLightCycleDispatcherTest.java
+++ b/lightcycle-lib/src/test/java/com/soundcloud/lightcycle/ActivityLightCycleDispatcherTest.java
@@ -102,6 +102,18 @@ public class ActivityLightCycleDispatcherTest {
     }
 
     @Test
+    public void dispatchOnActivityResult() {
+        int requestCode = 1;
+        int resultCode = 2;
+        Intent data = new Intent();
+
+        dispatcher.onActivityResult(requestCode, resultCode, data);
+
+        verify(lightCycleComponent1).onActivityResult(requestCode, resultCode, data);
+        verify(lightCycleComponent2).onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Test
     public void dispatchOnDestroy() {
         dispatcher.onDestroy(activity);
 


### PR DESCRIPTION
This PR adds dispatching of `void onActivityResult(int requestCode, int resultCode, Intent data)` to the `ActivityLightCycle`.

I think this is quite a handy callback to have at one's disposal.
Any chance of getting it merged for the next update to avoid maintaining a fork?
