### PR TITLE
More support baseclasses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,14 +31,17 @@ ext {
   targetCompatibilityVersion = JavaVersion.VERSION_1_7
 }
 
+def supportLibVersion = '23.1.1'
+
 ext.deps = [
   // Android
   android               : 'com.google.android:android:4.1.1.4',
   support_v4            : 'com.google.android:support-v4:r7',
-  appcompat_v7          : 'com.android.support:appcompat-v7:23.1.1',
-  support_annotations   : 'com.android.support:support-annotations:23.1.1',
+  preference_v7         : "com.android.support:preference-v7:${supportLibVersion}",
+  appcompat_v7          : "com.android.support:appcompat-v7:${supportLibVersion}",
+  support_annotations   : "com.android.support:support-annotations:${supportLibVersion}",
   // Processor
-  javapoet            : 'com.squareup:javapoet:1.6.1',
+  javapoet              : 'com.squareup:javapoet:1.6.1',
 
   // Test dependencies
   junit                 : 'junit:junit:4.12',

--- a/lightcycle-lib/build.gradle
+++ b/lightcycle-lib/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   compile project(':lightcycle-api')
   provided deps.support_v4
   compile deps.appcompat_v7
+  compile deps.preference_v7
   compile deps.support_annotations
 
   testCompile deps.mockito

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCyclePreferenceFragmentCompat.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCyclePreferenceFragmentCompat.java
@@ -1,0 +1,114 @@
+package com.soundcloud.lightcycle;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v7.preference.PreferenceFragmentCompat;
+import android.view.MenuItem;
+import android.view.View;
+
+public abstract class LightCyclePreferenceFragmentCompat<FragmentType extends Fragment>
+        extends PreferenceFragmentCompat implements LightCycleDispatcher<SupportFragmentLightCycle<FragmentType>> {
+
+    private final SupportFragmentLightCycleDispatcher<FragmentType> lifeCycleDispatcher;
+    private boolean bound;
+
+    public LightCyclePreferenceFragmentCompat() {
+        lifeCycleDispatcher = new SupportFragmentLightCycleDispatcher<>();
+    }
+
+    @Override
+    public void bind(SupportFragmentLightCycle<FragmentType> lifeCycleComponent) {
+        lifeCycleDispatcher.bind(lifeCycleComponent);
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        bindIfNecessary();
+        lifeCycleDispatcher.onAttach(fragment(), activity);
+    }
+
+    private void bindIfNecessary() {
+        if (!bound) {
+            LightCycles.bind(this);
+            bound = true;
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        lifeCycleDispatcher.onCreate(fragment(), savedInstanceState);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        lifeCycleDispatcher.onViewCreated(fragment(), view, savedInstanceState);
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        lifeCycleDispatcher.onActivityCreated(fragment(), savedInstanceState);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        lifeCycleDispatcher.onStart(fragment());
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        lifeCycleDispatcher.onResume(fragment());
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        return lifeCycleDispatcher.onOptionsItemSelected(fragment(), item);
+    }
+
+    @Override
+    public void onPause() {
+        lifeCycleDispatcher.onPause(fragment());
+        super.onPause();
+    }
+
+    @Override
+    public void onStop() {
+        lifeCycleDispatcher.onStop(fragment());
+        super.onStop();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        lifeCycleDispatcher.onSaveInstanceState(fragment(), outState);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onDestroyView() {
+        lifeCycleDispatcher.onDestroyView(fragment());
+        super.onDestroyView();
+    }
+
+    @Override
+    public void onDestroy() {
+        lifeCycleDispatcher.onDestroy(fragment());
+        super.onDestroy();
+    }
+
+    @Override
+    public void onDetach() {
+        lifeCycleDispatcher.onDetach(fragment());
+        super.onDetach();
+    }
+
+    @SuppressWarnings("unchecked")
+    private FragmentType fragment() {
+        return (FragmentType) this;
+    }
+}

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleSupportDialogFragment.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleSupportDialogFragment.java
@@ -1,0 +1,114 @@
+package com.soundcloud.lightcycle;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+import android.view.MenuItem;
+import android.view.View;
+
+public abstract class LightCycleSupportDialogFragment<FragmentType extends Fragment>
+        extends DialogFragment implements LightCycleDispatcher<SupportFragmentLightCycle<FragmentType>> {
+
+    private final SupportFragmentLightCycleDispatcher<FragmentType> lifeCycleDispatcher;
+    private boolean bound;
+
+    public LightCycleSupportDialogFragment() {
+        lifeCycleDispatcher = new SupportFragmentLightCycleDispatcher<>();
+    }
+
+    @Override
+    public void bind(SupportFragmentLightCycle<FragmentType> lifeCycleComponent) {
+        lifeCycleDispatcher.bind(lifeCycleComponent);
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        bindIfNecessary();
+        lifeCycleDispatcher.onAttach(fragment(), activity);
+    }
+
+    private void bindIfNecessary() {
+        if (!bound) {
+            LightCycles.bind(this);
+            bound = true;
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        lifeCycleDispatcher.onCreate(fragment(), savedInstanceState);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        lifeCycleDispatcher.onViewCreated(fragment(), view, savedInstanceState);
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        lifeCycleDispatcher.onActivityCreated(fragment(), savedInstanceState);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        lifeCycleDispatcher.onStart(fragment());
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        lifeCycleDispatcher.onResume(fragment());
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        return lifeCycleDispatcher.onOptionsItemSelected(fragment(), item);
+    }
+
+    @Override
+    public void onPause() {
+        lifeCycleDispatcher.onPause(fragment());
+        super.onPause();
+    }
+
+    @Override
+    public void onStop() {
+        lifeCycleDispatcher.onStop(fragment());
+        super.onStop();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        lifeCycleDispatcher.onSaveInstanceState(fragment(), outState);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onDestroyView() {
+        lifeCycleDispatcher.onDestroyView(fragment());
+        super.onDestroyView();
+    }
+
+    @Override
+    public void onDestroy() {
+        lifeCycleDispatcher.onDestroy(fragment());
+        super.onDestroy();
+    }
+
+    @Override
+    public void onDetach() {
+        lifeCycleDispatcher.onDetach(fragment());
+        super.onDetach();
+    }
+
+    @SuppressWarnings("unchecked")
+    private FragmentType fragment() {
+        return (FragmentType) this;
+    }
+}

--- a/lightcycle-processor/src/main/java/com/soundcloud/lightcycle/LightCycleDispatcherKind.java
+++ b/lightcycle-processor/src/main/java/com/soundcloud/lightcycle/LightCycleDispatcherKind.java
@@ -36,6 +36,17 @@ enum LightCycleDispatcherKind {
             return typeArgumentAsString("SupportFragmentLightCycle", dispatchedType);
         }
     },
+    DEFAULT_PREFERENCE_FRAGMENT {
+        @Override
+        boolean matches(Name name) {
+            return name.contentEquals("LightCyclePreferenceFragmentCompat");
+        }
+
+        @Override
+        String toTypeName(String dispatchedType) {
+            return typeArgumentAsString("SupportFragmentLightCycle", dispatchedType);
+        }
+    },
     BASE_ACTIVITY_DISPATCHER {
         @Override
         boolean matches(Name name) {

--- a/lightcycle-processor/src/main/java/com/soundcloud/lightcycle/LightCycleDispatcherKind.java
+++ b/lightcycle-processor/src/main/java/com/soundcloud/lightcycle/LightCycleDispatcherKind.java
@@ -47,6 +47,17 @@ enum LightCycleDispatcherKind {
             return typeArgumentAsString("SupportFragmentLightCycle", dispatchedType);
         }
     },
+    DEFAULT_SUPPORT_DIALOG_FRAGMENT {
+        @Override
+        boolean matches(Name name) {
+            return name.contentEquals("LightCycleSupportDialogFragment");
+        }
+
+        @Override
+        String toTypeName(String dispatchedType) {
+            return typeArgumentAsString("SupportFragmentLightCycle", dispatchedType);
+        }
+    },
     BASE_ACTIVITY_DISPATCHER {
         @Override
         boolean matches(Name name) {

--- a/lightcycle-processor/src/test/java/com/soundcloud/lightcycle/LightCycleProcessorTest.java
+++ b/lightcycle-processor/src/test/java/com/soundcloud/lightcycle/LightCycleProcessorTest.java
@@ -1,14 +1,15 @@
 package com.soundcloud.lightcycle;
 
-import static com.google.testing.compile.JavaFileObjects.forSourceString;
-import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-
 import com.google.common.base.Joiner;
 import com.google.testing.compile.JavaFileObjects;
+
 import org.junit.Test;
 import org.truth0.Truth;
 
 import javax.tools.JavaFileObject;
+
+import static com.google.testing.compile.JavaFileObjects.forSourceString;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 
 public class LightCycleProcessorTest {
 
@@ -50,6 +51,20 @@ public class LightCycleProcessorTest {
             "        target.bind(lightCycle2$Lifted);",
             "    }",
             "}");
+
+    private static final String LC_SUPPORT_DIALOG_FRAGMENT_BINDER_SRC = Joiner.on("\n").join(
+            "package com.test;",
+            "",
+            "public final class ValidTestLightCycleSupportDialogFragment$LightCycleBinder {",
+            "",
+            "    public static void bind(ValidTestLightCycleSupportDialogFragment target) {",
+            "        final com.soundcloud.lightcycle.SupportFragmentLightCycle<com.test.ValidTestLightCycleSupportDialogFragment> lightCycle1$Lifted = com.soundcloud.lightcycle.LightCycles.lift(target.lightCycle1);",
+            "        target.bind(lightCycle1$Lifted);",
+            "        final com.soundcloud.lightcycle.SupportFragmentLightCycle<com.test.ValidTestLightCycleSupportDialogFragment> lightCycle2$Lifted = com.soundcloud.lightcycle.LightCycles.lift(target.lightCycle2);",
+            "        target.bind(lightCycle2$Lifted);",
+            "    }",
+            "}");
+
 
     private static final String LC_SUPPORT_FRAGMENT_BINDER_SRC = Joiner.on("\n").join(
             "package com.test;",
@@ -194,6 +209,16 @@ public class LightCycleProcessorTest {
         JavaFileObject expectedSource = forSourceString("com.test.ValidTestLightCycleSupportFragment$LightCycleBinder", LC_SUPPORT_FRAGMENT_BINDER_SRC);
         Truth.ASSERT.about(javaSource())
                 .that(JavaFileObjects.forResource("com/test/ValidTestLightCycleSupportFragment.java"))
+                .processedWith(new LightCycleProcessor())
+                .compilesWithoutError()
+                .and().generatesSources(expectedSource);
+    }
+
+    @Test
+    public void shouldGenerateInjectorForLightCycleSupportDialogFragment() {
+        JavaFileObject expectedSource = forSourceString("com.test.ValidTestLightCycleSupportDialogFragment$LightCycleBinder", LC_SUPPORT_DIALOG_FRAGMENT_BINDER_SRC);
+        Truth.ASSERT.about(javaSource())
+                .that(JavaFileObjects.forResource("com/test/ValidTestLightCycleSupportDialogFragment.java"))
                 .processedWith(new LightCycleProcessor())
                 .compilesWithoutError()
                 .and().generatesSources(expectedSource);

--- a/lightcycle-processor/src/test/resources/com/soundcloud/lightcycle/LightCycleSupportDialogFragment.java
+++ b/lightcycle-processor/src/test/resources/com/soundcloud/lightcycle/LightCycleSupportDialogFragment.java
@@ -1,0 +1,15 @@
+package com.soundcloud.lightcycle;
+
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
+
+// Because neither the processor or the lib (java libraries) can depend on the api (Android library),
+// we have to create a fake `LightCycleSupportFragment` here for testing purpose.
+public abstract class LightCycleSupportDialogFragment<FragmentType extends Fragment>
+        extends DialogFragment
+        implements LightCycleDispatcher<SupportFragmentLightCycle<FragmentType>> {
+
+    @Override
+    public void bind(SupportFragmentLightCycle<FragmentType> lifeCycleComponent) { }
+
+}

--- a/lightcycle-processor/src/test/resources/com/test/ValidTestLightCycleSupportDialogFragment.java
+++ b/lightcycle-processor/src/test/resources/com/test/ValidTestLightCycleSupportDialogFragment.java
@@ -1,0 +1,21 @@
+package com.test;
+
+import com.soundcloud.lightcycle.ActivityLightCycle;
+import com.soundcloud.lightcycle.DefaultSupportFragmentLightCycle;
+import com.soundcloud.lightcycle.LightCycle;
+import com.soundcloud.lightcycle.LightCycleDispatcher;
+import com.soundcloud.lightcycle.LightCycleSupportDialogFragment;
+
+import android.app.Activity;
+
+public class ValidTestLightCycleSupportDialogFragment extends LightCycleSupportDialogFragment<ValidTestLightCycleSupportDialogFragment> {
+    @LightCycle DialogLightCycle1 lightCycle1;
+    @LightCycle DialogLightCycle2 lightCycle2;
+
+}
+
+class DialogLightCycle1 extends DefaultSupportFragmentLightCycle<ValidTestLightCycleSupportDialogFragment> {
+}
+
+class DialogLightCycle2 extends DefaultSupportFragmentLightCycle<ValidTestLightCycleSupportDialogFragment> {
+}


### PR DESCRIPTION
This PR adds 2 more base support classes that we are using. If we don't use these, then creating the `LightCycleBinder` classes fails with generics.