### PR TITLE
Support new onAttach(Context) on Fragment's lifecycle

### DIFF
--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/DefaultFragmentLightCycle.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/DefaultFragmentLightCycle.java
@@ -3,6 +3,7 @@ package com.soundcloud.lightcycle;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -12,6 +13,9 @@ import android.view.View;
 public class DefaultFragmentLightCycle<T extends Fragment> implements FragmentLightCycle<T> {
     @Override
     public void onAttach(T fragment, Activity activity) { /* no-op */ }
+
+    @Override
+    public void onAttach(T fragment, Context context) { /* no-op */ }
 
     @Override
     public void onCreate(T fragment, Bundle bundle) { /* no-op */ }

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/FragmentLightCycle.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/FragmentLightCycle.java
@@ -1,13 +1,18 @@
 package com.soundcloud.lightcycle;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
 
+@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public interface FragmentLightCycle<T extends Fragment> {
     void onAttach(T fragment, Activity activity);
+    @TargetApi(23) void onAttach(T fragment, Context context);
     void onCreate(T fragment, Bundle bundle);
     void onViewCreated(T fragment, View view, Bundle savedInstanceState);
     void onActivityCreated(T fragment, Bundle bundle);

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/FragmentLightCycle.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/FragmentLightCycle.java
@@ -12,7 +12,8 @@ import android.view.View;
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public interface FragmentLightCycle<T extends Fragment> {
     void onAttach(T fragment, Activity activity);
-    @TargetApi(23) void onAttach(T fragment, Context context);
+    @TargetApi(23)
+    void onAttach(T fragment, Context context);
     void onCreate(T fragment, Bundle bundle);
     void onViewCreated(T fragment, View view, Bundle savedInstanceState);
     void onActivityCreated(T fragment, Bundle bundle);

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/LightCycles.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/LightCycles.java
@@ -1,7 +1,10 @@
 package com.soundcloud.lightcycle;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.MenuItem;
@@ -105,12 +108,18 @@ public final class LightCycles {
         };
     }
 
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static <Source extends android.app.Fragment, Target extends Source> FragmentLightCycle<Target> lift(final FragmentLightCycle<Source> lightCycle) {
         return new FragmentLightCycle<Target>() {
 
             @Override
             public void onAttach(Target fragment, Activity activity) {
                 lightCycle.onAttach(fragment, activity);
+            }
+
+            @Override
+            public void onAttach(Target fragment, Context context) {
+                lightCycle.onAttach(fragment, context);
             }
 
             @Override

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
@@ -3,6 +3,7 @@ package com.soundcloud.lightcycle;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -33,6 +34,13 @@ public class FragmentLightCycleDispatcher<T extends Fragment>
     public void onAttach(T fragment, Activity activity) {
         for (FragmentLightCycle<T> component : fragmentLightCycles) {
             component.onAttach(fragment, activity);
+        }
+    }
+
+    @Override
+    public void onAttach(T fragment, Context context) {
+        for (FragmentLightCycle<T> component : fragmentLightCycles) {
+            component.onAttach(fragment, context);
         }
     }
 

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleFragment.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleFragment.java
@@ -3,6 +3,7 @@ package com.soundcloud.lightcycle;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -27,6 +28,19 @@ public abstract class LightCycleFragment<FragmentType extends Fragment> extends 
     }
 
     @Override
+    @TargetApi(23)
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        bindIfNecessary();
+        lifeCycleDispatcher.onAttach(fragment(), context);
+    }
+
+    /*
+     * Deprecated on API 23
+     * Use onAttach(Context) instead
+     */
+    @Override
+    @SuppressWarnings("deprecation")
     public void onAttach(Activity activity) {
         super.onAttach(activity);
         bindIfNecessary();

--- a/lightcycle-lib/src/test/java/com/soundcloud/lightcycle/FragmentLightCycleDispatcherTest.java
+++ b/lightcycle-lib/src/test/java/com/soundcloud/lightcycle/FragmentLightCycleDispatcherTest.java
@@ -11,6 +11,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
 
@@ -20,6 +21,7 @@ public class FragmentLightCycleDispatcherTest {
     @Mock private FragmentLightCycle<Fragment> lifeCycleComponent2;
     @Mock private Fragment fragment;
     @Mock private Activity activity;
+    @Mock private Context context;
     private FragmentLightCycleDispatcher<Fragment> dispatcher;
 
     @Before
@@ -35,6 +37,14 @@ public class FragmentLightCycleDispatcherTest {
 
         verify(lifeCycleComponent1).onAttach(fragment, activity);
         verify(lifeCycleComponent2).onAttach(fragment, activity);
+    }
+
+    @Test
+    public void shouldNotifyOnAttachAPI23() {
+        dispatcher.onAttach(fragment, context);
+
+        verify(lifeCycleComponent1).onAttach(fragment, context);
+        verify(lifeCycleComponent2).onAttach(fragment, context);
     }
 
     @Test

--- a/lightcycle-processor/src/test/resources/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
+++ b/lightcycle-processor/src/test/resources/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
@@ -25,6 +25,9 @@ public class FragmentLightCycleDispatcher<T extends Fragment>
     public void onAttach(T fragment, Activity activity) { }
 
     @Override
+    public void onAttach(T fragment, Context context) { }
+
+    @Override
     public void onCreate(T fragment, Bundle bundle) { }
 
     @Override

--- a/lightcycle-processor/src/test/resources/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
+++ b/lightcycle-processor/src/test/resources/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
@@ -3,6 +3,7 @@ package com.soundcloud.lightcycle;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;


### PR DESCRIPTION
Add onAttach(Context) on Fragment's lifecycle since onAttach(Activity) is deprecated since API 23

Reference : https://developer.android.com/reference/android/app/Fragment.html#onAttach(android.app.Activity)