### PR TITLE
Implement Checkstyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ android:
     - android-sdk-license-.*
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 branches:

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 task wrapper(type: Wrapper) {
   description 'Creates the gradle wrapper.'
-  gradleVersion '2.5'
+  gradleVersion '2.14.1'
 }
 
 allprojects {
@@ -51,8 +51,23 @@ ext.deps = [
 
 // Static analysis
 subprojects { project ->
+  apply plugin: 'checkstyle'
   apply plugin: 'pmd'
   apply plugin: 'findbugs'
+
+  checkstyle {
+    toolVersion = "7.2"
+    configFile rootProject.file('checkstyle.xml')
+  }
+
+  task checkstyle(type: Checkstyle) {
+    source 'src/main/java'
+    ignoreFailures false
+    showViolations true
+    include '**/*.java'
+
+    classpath = files()
+  }
 
   task pmd(type: Pmd) {
     description 'Finds common programming flaws throw static analysis of code.'

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<module name="Checker">
+    <!--module name="NewlineAtEndOfFile"/-->
+    <module name="FileLength"/>
+    <module name="FileTabCharacter"/>
+
+    <!-- Trailing spaces -->
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
+
+    <!-- Space after 'for' and 'if' -->
+    <module name="RegexpSingleline">
+        <property name="format" value="^\s*(for|if)\b[^ ]"/>
+        <property name="message" value="Space needed before opening parenthesis."/>
+    </module>
+
+    <!-- For each spacing -->
+    <module name="RegexpSingleline">
+        <property name="format" value="^\s*for \(.*?([^ ]:|:[^ ])"/>
+        <property name="message" value="Space needed around ':' character."/>
+    </module>
+
+    <module name="TreeWalker">
+
+        <!-- Checks for Annotation Location                               -->
+        <!-- See http://checkstyle.sourceforge.net/config_annotation.html -->
+        <module name="AnnotationLocation">
+            <property name="allowSamelineMultipleAnnotations" value="false"/>
+            <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
+            <property name="allowSamelineParameterizedAnnotation" value="false"/>
+        </module>
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
+        </module>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName">
+            <property name="format" value="^[A-Z][a-zA-Z0-9_]*$"/>
+        </module>
+
+
+        <!-- Checks for imports                              -->
+        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
+
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See http://checkstyle.sf.net/config_sizes.html -->
+        <module name="LineLength">
+            <property name="max" value="200"/>
+        </module>
+        <!--<module name="MethodLength"/>-->
+        <module name="ParameterNumber"/>
+
+
+        <!-- Checks for whitespace                               -->
+        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="GenericWhitespace"/>
+        <module name="EmptyForIteratorPad"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+
+
+        <!-- Modifier Checks                                    -->
+        <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+        <!--module name="ModifierOrder"/-->
+        <module name="RedundantModifier"/>
+
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <module name="AvoidNestedBlocks"/>
+        <!--<module name="EmptyBlock"/>-->
+        <module name="LeftCurly"/>
+        <module name="NeedBraces">
+            <property name="tokens" value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE"/>
+        </module>
+        <module name="RightCurly"/>
+
+
+        <!-- Checks for common coding problems               -->
+        <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <!--<module name="AvoidInlineConditionals"/>-->
+        <module name="CovariantEquals"/>
+        <!--<module name="DoubleCheckedLocking"/>-->
+        <module name="EmptyStatement"/>
+        <module name="EqualsAvoidNull"/>
+        <module name="EqualsHashCode"/>
+        <!--<module name="HiddenField"/>-->
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <!--<module name="MagicNumber"/>-->
+        <module name="MissingSwitchDefault"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See http://checkstyle.sf.net/config_design.html -->
+        <!--module name="DesignForExtension"/-->
+        <!--module name="FinalClass"/-->
+        <!--<module name="HideUtilityClassConstructor"/>-->
+        <module name="InterfaceIsType"/>
+        <!--<module name="VisibilityModifier"/>-->
+
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <module name="ArrayTypeStyle"/>
+        <!--module name="FinalParameters"/-->
+        <module name="TodoComment"/>
+        <module name="UpperEll"/>
+    </module>
+</module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -36,8 +36,8 @@
             <property name="allowSamelineParameterizedAnnotation" value="false"/>
         </module>
 
-        <!-- Checks for Naming Conventions.                  -->
-        <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <!-- Checks for Naming Conventions.                           -->
+        <!-- See http://checkstyle.sourceforge.net/config_naming.html -->
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
@@ -53,8 +53,8 @@
         </module>
 
 
-        <!-- Checks for imports                              -->
-        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <!-- Checks for imports                                        -->
+        <!-- See http://checkstyle.sourceforge.net/config_imports.html -->
         <module name="AvoidStarImport"/>
         <module name="IllegalImport"/>
         <module name="RedundantImport"/>
@@ -63,17 +63,16 @@
         </module>
 
 
-        <!-- Checks for Size Violations.                    -->
-        <!-- See http://checkstyle.sf.net/config_sizes.html -->
+        <!-- Checks for Size Violations.                             -->
+        <!-- See http://checkstyle.sourceforge.net/config_sizes.html -->
         <module name="LineLength">
             <property name="max" value="200"/>
         </module>
-        <!--<module name="MethodLength"/>-->
         <module name="ParameterNumber"/>
 
 
-        <!-- Checks for whitespace                               -->
-        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <!-- Checks for whitespace                                        -->
+        <!-- See http://checkstyle.sourceforge.net/config_whitespace.html -->
         <module name="GenericWhitespace"/>
         <module name="EmptyForIteratorPad"/>
         <module name="MethodParamPad"/>
@@ -86,16 +85,14 @@
         <module name="WhitespaceAround"/>
 
 
-        <!-- Modifier Checks                                    -->
-        <!-- See http://checkstyle.sf.net/config_modifiers.html -->
-        <!--module name="ModifierOrder"/-->
+        <!-- Modifier Checks                                            -->
+        <!-- See http://checkstyle.sourceforge.net/config_modifier.html -->
         <module name="RedundantModifier"/>
 
 
-        <!-- Checks for blocks. You know, those {}'s         -->
-        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <!-- Checks for blocks.                                       -->
+        <!-- See http://checkstyle.sourceforge.net/config_blocks.html -->
         <module name="AvoidNestedBlocks"/>
-        <!--<module name="EmptyBlock"/>-->
         <module name="LeftCurly"/>
         <module name="NeedBraces">
             <property name="tokens" value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE"/>
@@ -103,35 +100,26 @@
         <module name="RightCurly"/>
 
 
-        <!-- Checks for common coding problems               -->
-        <!-- See http://checkstyle.sf.net/config_coding.html -->
-        <!--<module name="AvoidInlineConditionals"/>-->
+        <!-- Checks for common coding problems                        -->
+        <!-- See http://checkstyle.sourceforge.net/config_coding.html -->
         <module name="CovariantEquals"/>
-        <!--<module name="DoubleCheckedLocking"/>-->
         <module name="EmptyStatement"/>
         <module name="EqualsAvoidNull"/>
         <module name="EqualsHashCode"/>
-        <!--<module name="HiddenField"/>-->
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
-        <!--<module name="MagicNumber"/>-->
         <module name="MissingSwitchDefault"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 
-        <!-- Checks for class design                         -->
-        <!-- See http://checkstyle.sf.net/config_design.html -->
-        <!--module name="DesignForExtension"/-->
-        <!--module name="FinalClass"/-->
-        <!--<module name="HideUtilityClassConstructor"/>-->
+        <!-- Checks for class design                                  -->
+        <!-- See http://checkstyle.sourceforge.net/config_design.html -->
         <module name="InterfaceIsType"/>
-        <!--<module name="VisibilityModifier"/>-->
 
 
-        <!-- Miscellaneous other checks.                   -->
-        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <!-- Miscellaneous other checks.                            -->
+        <!-- See http://checkstyle.sourceforge.net/config_misc.html -->
         <module name="ArrayTypeStyle"/>
-        <!--module name="FinalParameters"/-->
         <module name="TodoComment"/>
         <module name="UpperEll"/>
     </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -4,7 +4,6 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
-    <!--module name="NewlineAtEndOfFile"/-->
     <module name="FileLength"/>
     <module name="FileTabCharacter"/>
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 15 11:19:20 CET 2016
+#Sun Nov 13 16:29:51 JST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/lightcycle-api/build.gradle
+++ b/lightcycle-api/build.gradle
@@ -1,4 +1,10 @@
+apply plugin: 'checkstyle'
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+checkstyle {
+  configFile rootProject.file('checkstyle.xml')
+  showViolations true
+}
 
 dependencies {
   provided deps.android

--- a/lightcycle-lib/build.gradle
+++ b/lightcycle-lib/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'checkstyle'
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
 android {
@@ -32,6 +33,11 @@ android {
   testOptions {
     unitTests.returnDefaultValues = true
   }
+}
+
+checkstyle {
+  configFile rootProject.file('checkstyle.xml')
+  showViolations true
 }
 
 dependencies {

--- a/lightcycle-processor/build.gradle
+++ b/lightcycle-processor/build.gradle
@@ -1,4 +1,10 @@
+apply plugin: 'checkstyle'
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+checkstyle {
+  configFile rootProject.file('checkstyle.xml')
+  showViolations true
+}
 
 dependencies {
   compile project(':lightcycle-api')

--- a/lightcycle-processor/src/main/java/com/soundcloud/lightcycle/LightCycleProcessor.java
+++ b/lightcycle-processor/src/main/java/com/soundcloud/lightcycle/LightCycleProcessor.java
@@ -183,8 +183,8 @@ public class LightCycleProcessor extends AbstractProcessor {
     private void verifyFieldsAccessible(Set<? extends Element> elements) {
         for (Element element : elements) {
             if (element.getModifiers().contains(Modifier.PRIVATE)) {
-                throw new IllegalStateException("Annotated fields cannot be private: " +
-                        element.getEnclosingElement() + "#" + element + "(" + element.asType() + ")");
+                throw new IllegalStateException("Annotated fields cannot be private: "
+                        + element.getEnclosingElement() + "#" + element + "(" + element.asType() + ")");
             }
         }
     }

--- a/lightcycle-processor/src/test/java/com/soundcloud/lightcycle/InvalidCaseTest.java
+++ b/lightcycle-processor/src/test/java/com/soundcloud/lightcycle/InvalidCaseTest.java
@@ -20,8 +20,8 @@ public class InvalidCaseTest {
     @Test
     public void shouldThrowExceptionWhenLightCycleFieldIsPrivate() {
         expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("Annotated fields cannot be private: " +
-                "com.test.PrivateFieldsTestFragment#lightCycle1(com.test.LightCycle1)");
+        expectedException.expectMessage("Annotated fields cannot be private: "
+                + "com.test.PrivateFieldsTestFragment#lightCycle1(com.test.LightCycle1)");
 
         JavaFileObject privateFieldsTestFragment = forSourceString("com/test/PrivateFieldsTestFragment", Joiner.on("\n").join(
                 "package com.test;",
@@ -131,8 +131,8 @@ public class InvalidCaseTest {
                 .that(missingGenericTestActivity)
                 .processedWith(new LightCycleProcessor())
                 .failsToCompile()
-                .withErrorContaining("Expected 1 type argument but found 0. TypeArguments:[]. " +
-                        "Did you forget to add generic types?");
+                .withErrorContaining("Expected 1 type argument but found 0. TypeArguments:[]. "
+                        + "Did you forget to add generic types?");
     }
 
     @Test
@@ -164,7 +164,7 @@ public class InvalidCaseTest {
                 .that(dispatcherNotFoundTestActivity)
                 .processedWith(new LightCycleProcessor())
                 .failsToCompile()
-                .withErrorContaining("Could not find dispatcher type. " +
-                        "Did you forget to add the generic type?");
+                .withErrorContaining("Could not find dispatcher type. "
+                        + "Did you forget to add the generic type?");
     }
 }


### PR DESCRIPTION
Fix #65 (For the checkstyle)

Added the checkstyle plugin with these rules : 

## Annotation Location
- Annotation is not allowed to be located on same line with other annotations
- Single Parameterless Annotation is not allowed to be located on same line as target element
- Parameterized Annotation is not allowed to be located on the same line as target element

## Naming conventions

### With default format 
Refer to http://checkstyle.sourceforge.net/config_naming.html
ConstantName, LocalFinalVariableName, LocalVariableName, MemberName, PackageName, ParameterName, StaticVariableName

### With custom format
- Camel case with lowercase first letter for method name (Alphanumeric and underscore)
- Camel case with uppercase first letter for classes, interfaces, enums, and annotations (Alphanumeric and underscore)

## Imports
Refer to http://checkstyle.sourceforge.net/config_imports.html
AvoidStarImport, IllegalImport, RedundantImport, UnusedImports

## Size
- Line length must be less than 200 (I think this should be reduced in near future)]
- Parameter number must be less than 7

## Whitespaces 
Refer to http://checkstyle.sourceforge.net/config_whitespace.html  
GenericWhitespace, EmptyForIteratorPad, MethodParamPad, NoWhitespaceAfter, NoWhitespaceBefore, OperatorWrap, ParenPad, TypecastParenPad, WhitespaceAfter, WhitespaceAround

## Modifier
Refer to http://checkstyle.sourceforge.net/config_modifier.html
RedundantModifier

## Blocks
### With default rules 
Refer to http://checkstyle.sourceforge.net/config_blocks.html
AvoidNestedBlocks, LeftCurly, RightCurly

### With custom rules
Braces is mandatory (do-while, if-else, for, while)

## Common coding problems
Refer to http://checkstyle.sourceforge.net/config_coding.html
CovariantEquals, EmptyStatement, EqualsAvoidNull, EqualsHashCode, IllegalInstantiation, InnerAssignment, MissingSwitchDefault, SimplifyBooleanExpression, SimplifyBooleanReturn

## Class Design
Refer to http://checkstyle.sourceforge.net/config_design.html
InterfaceIsType

## Miscellaneous cheks
ArrayTypeStyle, TodoComment, UpperEll

## Custom rules
- No trailing spaces in lines
- Spaces after for and if
- Space around colon in for each