### PR TITLE
Update gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ before_script:
 
 android:
   components:
+    - tools
+    - platform-tools
+    - tools # This duplication is intented to make travis accept license, please check https://github.com/travis-ci/docs-travis-ci-com/issues/779
     - build-tools-25.0.1
     - android-25
-    - platform-tools
-    - extra-android-m2repository
   licenses:
     - 'android-sdk-preview-license-52d11cd2'
     - 'android-sdk-license-.+'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_script:
 
 android:
   components:
-    - build-tools-23.0.1
-    - android-23
+    - build-tools-25.0.1
+    - android-25
     - platform-tools
     - extra-android-m2repository
   licenses:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ android:
     - platform-tools
     - extra-android-m2repository
   licenses:
-    - android-sdk-license-.*
+    - 'android-sdk-preview-license-52d11cd2'
+    - 'android-sdk-license-.+'
+    - 'google-gdk-license-.+'
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ android:
     - tools # This duplication is intented to make travis accept license, please check https://github.com/travis-ci/docs-travis-ci-com/issues/779
     - build-tools-25.0.1
     - android-25
+    - extra-android-support
   licenses:
     - 'android-sdk-preview-license-52d11cd2'
     - 'android-sdk-license-.+'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ android:
     - tools # This duplication is intented to make travis accept license, please check https://github.com/travis-ci/docs-travis-ci-com/issues/779
     - build-tools-25.0.1
     - android-25
-    - extra-android-support
+    - extra-android-m2repository
   licenses:
     - 'android-sdk-preview-license-52d11cd2'
     - 'android-sdk-license-.+'

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ See for example [LightCycleActionBarActivity](lightcycle-lib/src/main/java/com/s
 Gradle:
 
 ```gradle
+ext.lightCycleVersion=<LATEST_VERSION>
+
+dependencies {
+  compile "com.soundcloud.lightcycle:lightcycle-lib:$lightCycleVersion"
+  annotationProcessor "com.soundcloud.lightcycle:lightcycle-processor:$lightCycleVersion"
+}
+```
+
+Or if you're using a version of the Android gradle plugin below `2.2.0`
+
+```gradle
 buildscript {
   dependencies {
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
   repositories {
     mavenLocal()
-    mavenCentral()
     jcenter()
   }
   dependencies {
@@ -18,20 +17,20 @@ task wrapper(type: Wrapper) {
 allprojects {
   repositories {
     mavenLocal()
-    mavenCentral()
+    jcenter()
   }
 }
 
 ext {
-  minSdkVersion = 8
-  targetSdkVersion = 23
-  compileSdkVersion = 23
-  buildToolsVersion = '23.0.1'
+  minSdkVersion = 9
+  targetSdkVersion = 25
+  compileSdkVersion = 25
+  buildToolsVersion = '25.0.1'
   sourceCompatibilityVersion = JavaVersion.VERSION_1_7
   targetCompatibilityVersion = JavaVersion.VERSION_1_7
 }
 
-def supportLibVersion = '23.1.1'
+def supportLibVersion = '25.0.1'
 
 ext.deps = [
   // Android

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -1,17 +1,14 @@
 buildscript {
   repositories {
-    mavenCentral()
+    jcenter()
   }
   dependencies {
     // replace with the current version of the Android plugin
-    classpath 'com.android.tools.build:gradle:1.5.0'
-    // the latest version of the android-apt plugin
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+    classpath 'com.android.tools.build:gradle:2.2.0'
   }
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'android-apt'
 
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
@@ -32,7 +29,7 @@ android {
 }
 
 dependencies {
-  apt project(":lightcycle-processor")
+  annotationProcessor project(":lightcycle-processor")
 
   compile project(":lightcycle-lib")
   compile deps.appcompat_v7

--- a/examples/real-world/build.gradle
+++ b/examples/real-world/build.gradle
@@ -1,17 +1,14 @@
 buildscript {
   repositories {
-    mavenCentral()
+    jcenter()
   }
   dependencies {
     // replace with the current version of the Android plugin
-    classpath 'com.android.tools.build:gradle:1.5.0'
-    // the latest version of the android-apt plugin
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+    classpath 'com.android.tools.build:gradle:2.2.2'
   }
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'android-apt'
 
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
@@ -31,10 +28,10 @@ android {
 }
 
 dependencies {
-  apt project(":lightcycle-processor")
+  annotationProcessor project(":lightcycle-processor")
   compile project(":lightcycle-lib")
 
-  apt "com.squareup.dagger:dagger-compiler:1.2.2"
+  annotationProcessor "com.squareup.dagger:dagger-compiler:1.2.2"
   compile "com.squareup.dagger:dagger:1.2.2"
 
   compile deps.appcompat_v7

--- a/lightcycle-integration-test/build.gradle
+++ b/lightcycle-integration-test/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-    }
-}
-
 apply plugin: 'com.android.application'
-apply plugin: 'android-apt'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -29,7 +19,7 @@ android {
 }
 
 dependencies {
-    apt project(":lightcycle-processor")
+    annotationProcessor project(":lightcycle-processor")
 
     compile project(":lightcycle-lib")
     compile deps.appcompat_v7


### PR DESCRIPTION
- Migrate maven central to jcenter
- Update build tools to 25.0.1
- Upgrade target & compile sdk version to 25 and min sdk to 9 (minimum version for build tools 25.0.1)
- Replace apt with annotationProcessor (remove dependencies and use the official one since android gradle plugin 2.2.0)
- Update readme to add instruction for new annotationProcessor command ([details here](https://developer.android.com/studio/releases/gradle-plugin.html))