### PR TITLE
Add LightCycles.bind() to the built-in dispatchers section readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ public class MyController extends ActivityLightCycleDispatcher<MyActivity> {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        LightCycles.bind(this) // <- bind the lightcycles
         [...] // <- specific init 
         super.onCreate(savedInstanceState) // <- call super to dispatch.
     }


### PR DESCRIPTION
Fix #36 

@glung So we agree to use solution number one (for anyone else, please see the discussion in the issue) 

- Keep the auto-binding for Activity and Fragment
- Add rule for when the LightCycles.bind() need to be called in Dispatchers and add them to Readme (Possibly in [Built-in dispatcher](https://github.com/soundcloud/lightcycle#built-in-dispatchers) section)

So I added the LightCycles.bind() into Built-in Dispatcher section, to make it clearer for the user when to call LightCycles.bind()

Let me know if you have any feedback or different idea! :)