### PR TITLE
Fix auto-binding issue in Fragments for 1.5.0. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ ext.deps = [
   compiletesting        : 'com.google.testing.compile:compile-testing:0.7',
   roboelectric          : 'org.robolectric:robolectric:3.1.2',
   robolectric_support   : 'org.robolectric:shadows-support-v4:3.1.2',
+  equalsverifier        : 'nl.jqno.equalsverifier:equalsverifier:2.1.8'
 ]
 
 // Static analysis

--- a/examples/real-world/src/main/java/com/soundcloud/lightcycle/sample/real_world/HomePresenter.java
+++ b/examples/real-world/src/main/java/com/soundcloud/lightcycle/sample/real_world/HomePresenter.java
@@ -2,10 +2,6 @@ package com.soundcloud.lightcycle.sample.real_world;
 
 import com.soundcloud.lightcycle.ActivityLightCycleDispatcher;
 import com.soundcloud.lightcycle.LightCycle;
-import com.soundcloud.lightcycle.LightCycles;
-
-import android.os.Bundle;
-import android.support.annotation.Nullable;
 
 import javax.inject.Inject;
 
@@ -17,11 +13,5 @@ class HomePresenter extends ActivityLightCycleDispatcher<HomeActivity> {
     HomePresenter(HeaderPresenter headerPresenter, DescriptionPresenter descriptionPresenter) {
         this.headerPresenter = headerPresenter;
         this.descriptionPresenter = descriptionPresenter;
-    }
-
-    @Override
-    public void onCreate(HomeActivity activity, @Nullable Bundle bundle) {
-        LightCycles.bind(this);
-        super.onCreate(activity, bundle);
     }
 }

--- a/lightcycle-api/build.gradle
+++ b/lightcycle-api/build.gradle
@@ -5,8 +5,10 @@ checkstyle {
   configFile rootProject.file('checkstyle.xml')
   showViolations true
 }
-
 dependencies {
   provided deps.android
   provided deps.support_v4
+
+  testCompile deps.junit
+  testCompile deps.equalsverifier
 }

--- a/lightcycle-api/src/main/java/com/soundcloud/lightcycle/LightCycles.java
+++ b/lightcycle-api/src/main/java/com/soundcloud/lightcycle/LightCycles.java
@@ -17,6 +17,8 @@ public final class LightCycles {
     private static final String ANDROID_PREFIX = "android.";
     private static final String JAVA_PREFIX = "java.";
 
+
+
     @SuppressWarnings("PMD.EmptyCatchBlock")
     public static void bind(LightCycleDispatcher<?> target) {
         Method bindingMethod;
@@ -54,204 +56,288 @@ public final class LightCycles {
     }
 
     public static <Source extends Activity, Target extends Source> ActivityLightCycle<Target> lift(final ActivityLightCycle<Source> lightCycle) {
-        return new ActivityLightCycle<Target>() {
-
-            @Override
-            public void onCreate(Target activity, Bundle bundle) {
-                lightCycle.onCreate(activity, bundle);
-            }
-
-            @Override
-            public void onNewIntent(Target activity, Intent intent) {
-                lightCycle.onNewIntent(activity, intent);
-            }
-
-            @Override
-            public void onStart(Target activity) {
-                lightCycle.onStart(activity);
-            }
-
-            @Override
-            public void onResume(Target activity) {
-                lightCycle.onResume(activity);
-            }
-
-            @Override
-            public boolean onOptionsItemSelected(Target activity, MenuItem item) {
-                return lightCycle.onOptionsItemSelected(activity, item);
-            }
-
-            @Override
-            public void onPause(Target activity) {
-                lightCycle.onPause(activity);
-            }
-
-            @Override
-            public void onStop(Target activity) {
-                lightCycle.onStop(activity);
-            }
-
-            @Override
-            public void onSaveInstanceState(Target activity, Bundle bundle) {
-                lightCycle.onSaveInstanceState(activity, bundle);
-            }
-
-            @Override
-            public void onRestoreInstanceState(Target activity, Bundle bundle) {
-                lightCycle.onRestoreInstanceState(activity, bundle);
-            }
-
-            @Override
-            public void onDestroy(Target activity) {
-                lightCycle.onDestroy(activity);
-            }
-        };
+        return new LiftedActivityLightCycle<>(lightCycle);
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static <Source extends android.app.Fragment, Target extends Source> FragmentLightCycle<Target> lift(final FragmentLightCycle<Source> lightCycle) {
-        return new FragmentLightCycle<Target>() {
-
-            @Override
-            public void onAttach(Target fragment, Activity activity) {
-                lightCycle.onAttach(fragment, activity);
-            }
-
-            @Override
-            public void onAttach(Target fragment, Context context) {
-                lightCycle.onAttach(fragment, context);
-            }
-
-            @Override
-            public void onCreate(Target fragment, Bundle bundle) {
-                lightCycle.onCreate(fragment, bundle);
-            }
-
-            @Override
-            public void onViewCreated(Target fragment, View view, Bundle savedInstanceState) {
-                lightCycle.onViewCreated(fragment, view, savedInstanceState);
-            }
-
-            @Override
-            public void onActivityCreated(Target fragment, Bundle bundle) {
-                lightCycle.onActivityCreated(fragment, bundle);
-            }
-
-            @Override
-            public void onStart(Target fragment) {
-                lightCycle.onStart(fragment);
-            }
-
-            @Override
-            public void onResume(Target fragment) {
-                lightCycle.onResume(fragment);
-            }
-
-            @Override
-            public boolean onOptionsItemSelected(Target fragment, MenuItem item) {
-                return lightCycle.onOptionsItemSelected(fragment, item);
-            }
-
-            @Override
-            public void onPause(Target fragment) {
-                lightCycle.onPause(fragment);
-            }
-
-            @Override
-            public void onStop(Target fragment) {
-                lightCycle.onStop(fragment);
-            }
-
-            @Override
-            public void onSaveInstanceState(Target fragment, Bundle bundle) {
-                lightCycle.onSaveInstanceState(fragment, bundle);
-            }
-
-            @Override
-            public void onDestroyView(Target fragment) {
-                lightCycle.onDestroyView(fragment);
-            }
-
-            @Override
-            public void onDestroy(Target fragment) {
-                lightCycle.onDestroy(fragment);
-            }
-
-            @Override
-            public void onDetach(Target fragment) {
-                lightCycle.onDetach(fragment);
-            }
-        };
+        return new LiftedFragmentLightCycle<>(lightCycle);
     }
 
 
     public static <Source extends android.support.v4.app.Fragment, Target extends Source> SupportFragmentLightCycle<Target> lift(final SupportFragmentLightCycle<Source> lightCycle) {
-        return new SupportFragmentLightCycle<Target>() {
+        return new LiftedSupportFragmentLightCycle<>(lightCycle);
+    }
 
-            @Override
-            public void onAttach(Target fragment, Activity activity) {
-                lightCycle.onAttach(fragment, activity);
+    static final class LiftedActivityLightCycle<Source extends Activity, Target extends Source> implements ActivityLightCycle<Target> {
+
+        private final ActivityLightCycle<Source> lightCycle;
+
+        LiftedActivityLightCycle(ActivityLightCycle<Source> lightCycle) {
+            this.lightCycle = lightCycle;
+        }
+
+        @Override
+        public void onCreate(Target activity, Bundle bundle) {
+            lightCycle.onCreate(activity, bundle);
+        }
+
+        @Override
+        public void onNewIntent(Target activity, Intent intent) {
+            lightCycle.onNewIntent(activity, intent);
+        }
+
+        @Override
+        public void onStart(Target activity) {
+            lightCycle.onStart(activity);
+        }
+
+        @Override
+        public void onResume(Target activity) {
+            lightCycle.onResume(activity);
+        }
+
+        @Override
+        public boolean onOptionsItemSelected(Target activity, MenuItem item) {
+            return lightCycle.onOptionsItemSelected(activity, item);
+        }
+
+        @Override
+        public void onPause(Target activity) {
+            lightCycle.onPause(activity);
+        }
+
+        @Override
+        public void onStop(Target activity) {
+            lightCycle.onStop(activity);
+        }
+
+        @Override
+        public void onSaveInstanceState(Target activity, Bundle bundle) {
+            lightCycle.onSaveInstanceState(activity, bundle);
+        }
+
+        @Override
+        public void onRestoreInstanceState(Target activity, Bundle bundle) {
+            lightCycle.onRestoreInstanceState(activity, bundle);
+        }
+
+        @Override
+        public void onDestroy(Target activity) {
+            lightCycle.onDestroy(activity);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
             }
 
-            @Override
-            public void onCreate(Target fragment, Bundle bundle) {
-                lightCycle.onCreate(fragment, bundle);
+            LiftedActivityLightCycle<?, ?> that = (LiftedActivityLightCycle<?, ?>) o;
+
+            return lightCycle != null ? lightCycle.equals(that.lightCycle) : that.lightCycle == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return lightCycle != null ? lightCycle.hashCode() : 0;
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    static final class LiftedFragmentLightCycle<Source extends android.app.Fragment, Target extends Source> implements FragmentLightCycle<Target> {
+
+        private final FragmentLightCycle<Source> lightCycle;
+
+        LiftedFragmentLightCycle(FragmentLightCycle<Source> lightCycle) {
+            this.lightCycle = lightCycle;
+        }
+
+        @Override
+        public void onAttach(Target fragment, Activity activity) {
+            lightCycle.onAttach(fragment, activity);
+        }
+
+        @Override
+        public void onAttach(Target fragment, Context context) {
+            lightCycle.onAttach(fragment, context);
+        }
+
+        @Override
+        public void onCreate(Target fragment, Bundle bundle) {
+            lightCycle.onCreate(fragment, bundle);
+        }
+
+        @Override
+        public void onViewCreated(Target fragment, View view, Bundle savedInstanceState) {
+            lightCycle.onViewCreated(fragment, view, savedInstanceState);
+        }
+
+        @Override
+        public void onActivityCreated(Target fragment, Bundle bundle) {
+            lightCycle.onActivityCreated(fragment, bundle);
+        }
+
+        @Override
+        public void onStart(Target fragment) {
+            lightCycle.onStart(fragment);
+        }
+
+        @Override
+        public void onResume(Target fragment) {
+            lightCycle.onResume(fragment);
+        }
+
+        @Override
+        public boolean onOptionsItemSelected(Target fragment, MenuItem item) {
+            return lightCycle.onOptionsItemSelected(fragment, item);
+        }
+
+        @Override
+        public void onPause(Target fragment) {
+            lightCycle.onPause(fragment);
+        }
+
+        @Override
+        public void onStop(Target fragment) {
+            lightCycle.onStop(fragment);
+        }
+
+        @Override
+        public void onSaveInstanceState(Target fragment, Bundle bundle) {
+            lightCycle.onSaveInstanceState(fragment, bundle);
+        }
+
+        @Override
+        public void onDestroyView(Target fragment) {
+            lightCycle.onDestroyView(fragment);
+        }
+
+        @Override
+        public void onDestroy(Target fragment) {
+            lightCycle.onDestroy(fragment);
+        }
+
+        @Override
+        public void onDetach(Target fragment) {
+            lightCycle.onDetach(fragment);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
             }
 
-            @Override
-            public void onViewCreated(Target fragment, View view, Bundle savedInstanceState) {
-                lightCycle.onViewCreated(fragment, view, savedInstanceState);
+            LiftedFragmentLightCycle<?, ?> that = (LiftedFragmentLightCycle<?, ?>) o;
+
+            return lightCycle != null ? lightCycle.equals(that.lightCycle) : that.lightCycle == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            return lightCycle != null ? lightCycle.hashCode() : 0;
+        }
+    }
+
+    static final class LiftedSupportFragmentLightCycle<Source extends android.support.v4.app.Fragment, Target extends Source> implements SupportFragmentLightCycle<Target> {
+
+        private final SupportFragmentLightCycle<Source> lightCycle;
+
+        LiftedSupportFragmentLightCycle(SupportFragmentLightCycle<Source> lightCycle) {
+            this.lightCycle = lightCycle;
+        }
+
+        @Override
+        public void onAttach(Target fragment, Activity activity) {
+            lightCycle.onAttach(fragment, activity);
+        }
+
+        @Override
+        public void onCreate(Target fragment, Bundle bundle) {
+            lightCycle.onCreate(fragment, bundle);
+        }
+
+        @Override
+        public void onViewCreated(Target fragment, View view, Bundle savedInstanceState) {
+            lightCycle.onViewCreated(fragment, view, savedInstanceState);
+        }
+
+        @Override
+        public void onActivityCreated(Target fragment, Bundle bundle) {
+            lightCycle.onActivityCreated(fragment, bundle);
+        }
+
+        @Override
+        public void onStart(Target fragment) {
+            lightCycle.onStart(fragment);
+        }
+
+        @Override
+        public void onResume(Target fragment) {
+            lightCycle.onResume(fragment);
+        }
+
+        @Override
+        public boolean onOptionsItemSelected(Target fragment, MenuItem item) {
+            return lightCycle.onOptionsItemSelected(fragment, item);
+        }
+
+        @Override
+        public void onPause(Target fragment) {
+            lightCycle.onPause(fragment);
+        }
+
+        @Override
+        public void onStop(Target fragment) {
+            lightCycle.onStop(fragment);
+        }
+
+        @Override
+        public void onSaveInstanceState(Target fragment, Bundle bundle) {
+            lightCycle.onSaveInstanceState(fragment, bundle);
+        }
+
+        @Override
+        public void onDestroyView(Target fragment) {
+            lightCycle.onDestroyView(fragment);
+        }
+
+        @Override
+        public void onDestroy(Target fragment) {
+            lightCycle.onDestroy(fragment);
+        }
+
+        @Override
+        public void onDetach(Target fragment) {
+            lightCycle.onDetach(fragment);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
             }
 
-            @Override
-            public void onActivityCreated(Target fragment, Bundle bundle) {
-                lightCycle.onActivityCreated(fragment, bundle);
-            }
+            LiftedSupportFragmentLightCycle<?, ?> that = (LiftedSupportFragmentLightCycle<?, ?>) o;
 
-            @Override
-            public void onStart(Target fragment) {
-                lightCycle.onStart(fragment);
-            }
+            return lightCycle != null ? lightCycle.equals(that.lightCycle) : that.lightCycle == null;
 
-            @Override
-            public void onResume(Target fragment) {
-                lightCycle.onResume(fragment);
-            }
+        }
 
-            @Override
-            public boolean onOptionsItemSelected(Target fragment, MenuItem item) {
-                return lightCycle.onOptionsItemSelected(fragment, item);
-            }
-
-            @Override
-            public void onPause(Target fragment) {
-                lightCycle.onPause(fragment);
-            }
-
-            @Override
-            public void onStop(Target fragment) {
-                lightCycle.onStop(fragment);
-            }
-
-            @Override
-            public void onSaveInstanceState(Target fragment, Bundle bundle) {
-                lightCycle.onSaveInstanceState(fragment, bundle);
-            }
-
-            @Override
-            public void onDestroyView(Target fragment) {
-                lightCycle.onDestroyView(fragment);
-            }
-
-            @Override
-            public void onDestroy(Target fragment) {
-                lightCycle.onDestroy(fragment);
-            }
-
-            @Override
-            public void onDetach(Target fragment) {
-                lightCycle.onDetach(fragment);
-            }
-        };
+        @Override
+        public int hashCode() {
+            return lightCycle != null ? lightCycle.hashCode() : 0;
+        }
     }
 }

--- a/lightcycle-api/src/test/java/com/soundcloud/lightcycle/LightCyclesTest.java
+++ b/lightcycle-api/src/test/java/com/soundcloud/lightcycle/LightCyclesTest.java
@@ -1,0 +1,61 @@
+package com.soundcloud.lightcycle;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsSame.sameInstance;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+import android.app.Activity;
+import android.app.Fragment;
+
+public class LightCyclesTest {
+
+    @Test
+    public void liftedActivityLightCycleEqualsContract() {
+        EqualsVerifier.forClass(LightCycles.LiftedActivityLightCycle.class).verify();
+    }
+
+    @Test
+    public void liftedFragmentLightCycleEqualsContract() {
+        EqualsVerifier.forClass(LightCycles.LiftedFragmentLightCycle.class).verify();
+    }
+
+    @Test
+    public void liftedSupportFragmentLightCycleEqualsContract() {
+        EqualsVerifier.forClass(LightCycles.LiftedSupportFragmentLightCycle.class).verify();
+    }
+
+    @Test
+    public void liftedActivityLightCycleAreEqualsWhenTheSourceIsTheSame() {
+        final DefaultActivityLightCycle<Activity> lightCycle = new DefaultActivityLightCycle<>();
+        final ActivityLightCycle<Activity> lift1 = LightCycles.lift(lightCycle);
+        final ActivityLightCycle<Activity> lift2 = LightCycles.lift(lightCycle);
+
+        assertThat(lift1, not(sameInstance(lift2)));
+        assertThat(lift1, equalTo(lift2));
+    }
+
+    @Test
+    public void liftedFragmentLightCycleAreEqualsWhenTheSourceIsTheSame() {
+        final DefaultFragmentLightCycle<Fragment> lightCycle = new DefaultFragmentLightCycle<>();
+        final FragmentLightCycle<Fragment> lift1 = LightCycles.lift(lightCycle);
+        final FragmentLightCycle<Fragment> lift2 = LightCycles.lift(lightCycle);
+
+        assertThat(lift1, not(sameInstance(lift2)));
+        assertThat(lift1, equalTo(lift2));
+    }
+
+    @Test
+    public void liftedSupportFragmentLightCycleAreEqualsWhenTheSourceIsTheSame() {
+        final DefaultSupportFragmentLightCycle<android.support.v4.app.Fragment> lightCycle = new DefaultSupportFragmentLightCycle<>();
+        final SupportFragmentLightCycle<android.support.v4.app.Fragment> lift1 = LightCycles.lift(lightCycle);
+        final SupportFragmentLightCycle<android.support.v4.app.Fragment> lift2 = LightCycles.lift(lightCycle);
+
+        assertThat(lift1, not(sameInstance(lift2)));
+        assertThat(lift1, equalTo(lift2));
+    }
+
+}

--- a/lightcycle-integration-test/src/main/java/com/soundcloud/lightcycle/integration_test/SampleFragment.java
+++ b/lightcycle-integration-test/src/main/java/com/soundcloud/lightcycle/integration_test/SampleFragment.java
@@ -1,21 +1,36 @@
 package com.soundcloud.lightcycle.integration_test;
 
+import com.soundcloud.lightcycle.FragmentLightCycle;
+import com.soundcloud.lightcycle.LightCycle;
+import com.soundcloud.lightcycle.LightCycleFragment;
+import com.soundcloud.lightcycle.sample.basic.R;
+
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.soundcloud.lightcycle.LightCycle;
-import com.soundcloud.lightcycle.LightCycleFragment;
-import com.soundcloud.lightcycle.sample.basic.R;
-
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public class SampleFragment extends LightCycleFragment<SampleFragment> {
 
-    @LightCycle
-    FragmentLogger fragmentLogger = new FragmentLogger();
+    @LightCycle FragmentLogger fragmentLogger = new FragmentLogger();
+    int bindCount = 0;
+    int onAttachCount = 0;
+
+    @Override
+    public void bind(FragmentLightCycle<SampleFragment> lifeCycleComponent) {
+        super.bind(lifeCycleComponent);
+        bindCount++;
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        onAttachCount++;
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {

--- a/lightcycle-integration-test/src/main/java/com/soundcloud/lightcycle/integration_test/SampleFragmentDispatcher.java
+++ b/lightcycle-integration-test/src/main/java/com/soundcloud/lightcycle/integration_test/SampleFragmentDispatcher.java
@@ -1,0 +1,20 @@
+package com.soundcloud.lightcycle.integration_test;
+
+import com.soundcloud.lightcycle.DefaultFragmentLightCycle;
+import com.soundcloud.lightcycle.FragmentLightCycle;
+import com.soundcloud.lightcycle.FragmentLightCycleDispatcher;
+import com.soundcloud.lightcycle.LightCycle;
+
+import android.app.Fragment;
+
+class SampleFragmentDispatcher extends FragmentLightCycleDispatcher<Fragment> {
+    @LightCycle DefaultFragmentLightCycle<Fragment> lightCycle = new DefaultFragmentLightCycle<>();
+
+    int bindCount = 0;
+
+    @Override
+    public void bind(FragmentLightCycle<Fragment> lightCycle) {
+        super.bind(lightCycle);
+        bindCount++;
+    }
+}

--- a/lightcycle-integration-test/src/main/java/com/soundcloud/lightcycle/integration_test/SampleSupportFragment.java
+++ b/lightcycle-integration-test/src/main/java/com/soundcloud/lightcycle/integration_test/SampleSupportFragment.java
@@ -1,18 +1,34 @@
 package com.soundcloud.lightcycle.integration_test;
 
+import com.soundcloud.lightcycle.LightCycle;
+import com.soundcloud.lightcycle.LightCycleSupportFragment;
+import com.soundcloud.lightcycle.SupportFragmentLightCycle;
+import com.soundcloud.lightcycle.sample.basic.R;
+
+import android.app.Activity;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.soundcloud.lightcycle.LightCycle;
-import com.soundcloud.lightcycle.LightCycleSupportFragment;
-import com.soundcloud.lightcycle.sample.basic.R;
-
 public class SampleSupportFragment extends LightCycleSupportFragment<SampleSupportFragment> {
 
     @LightCycle
     SupportFragmentLogger supportFragmentLogger = new SupportFragmentLogger();
+    public int onAttachCount;
+    public int bindCount;
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        onAttachCount++;
+    }
+
+    @Override
+    public void bind(SupportFragmentLightCycle<SampleSupportFragment> lifeCycleComponent) {
+        super.bind(lifeCycleComponent);
+        bindCount++;
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {

--- a/lightcycle-integration-test/src/main/java/com/soundcloud/lightcycle/integration_test/SampleSupportFragmentDispatcher.java
+++ b/lightcycle-integration-test/src/main/java/com/soundcloud/lightcycle/integration_test/SampleSupportFragmentDispatcher.java
@@ -1,0 +1,20 @@
+package com.soundcloud.lightcycle.integration_test;
+
+import com.soundcloud.lightcycle.DefaultSupportFragmentLightCycle;
+import com.soundcloud.lightcycle.LightCycle;
+import com.soundcloud.lightcycle.SupportFragmentLightCycle;
+import com.soundcloud.lightcycle.SupportFragmentLightCycleDispatcher;
+
+import android.support.v4.app.Fragment;
+
+class SampleSupportFragmentDispatcher extends SupportFragmentLightCycleDispatcher<Fragment> {
+    @LightCycle DefaultSupportFragmentLightCycle<Fragment> lightCycle = new DefaultSupportFragmentLightCycle<>();
+
+    int bindCount = 0;
+
+    @Override
+    public void bind(SupportFragmentLightCycle<Fragment> lightCycle) {
+        super.bind(lightCycle);
+        bindCount++;
+    }
+}

--- a/lightcycle-integration-test/src/test/java/com/soundcloud/lightcycle/integration_test/FragmentLoggerTest.java
+++ b/lightcycle-integration-test/src/test/java/com/soundcloud/lightcycle/integration_test/FragmentLoggerTest.java
@@ -1,21 +1,21 @@
 package com.soundcloud.lightcycle.integration_test;
 
-import android.os.Bundle;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.truth.BooleanSubject;
 import com.soundcloud.lightcycle.integration_test.callback.FragmentLifecycleCallback;
 import com.soundcloud.lightcycle.sample.basic.BuildConfig;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.FragmentController;
+import utils.FragmentTestHelper;
+
+import android.os.Bundle;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 22)
@@ -128,6 +128,18 @@ public class FragmentLoggerTest {
                         FragmentLifecycleCallback.onDestroy,
                         FragmentLifecycleCallback.onDetach)
         );
+    }
+
+    @Test
+    public void bindFragmentOnlyOnceWhenReAttched() {
+        FragmentTestHelper
+                .from(sampleFragment)
+                .addFragment()
+                .removeFragment()
+                .addFragment();
+
+        assertThat(sampleFragment.onAttachCount).is(2);
+        assertThat(sampleFragment.bindCount).is(1);
     }
 
     private void assertLifecycleCallbackCallIsCorrect(List<FragmentLifecycleCallback> callbacks) {

--- a/lightcycle-integration-test/src/test/java/com/soundcloud/lightcycle/integration_test/SampleFragmentDispatcherTest.java
+++ b/lightcycle-integration-test/src/test/java/com/soundcloud/lightcycle/integration_test/SampleFragmentDispatcherTest.java
@@ -1,0 +1,29 @@
+package com.soundcloud.lightcycle.integration_test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.soundcloud.lightcycle.sample.basic.BuildConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import android.app.Activity;
+import android.app.Fragment;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 22)
+public class SampleFragmentDispatcherTest {
+    private Fragment fragment = new SampleFragment();
+    private Activity activity = new SampleActivity();
+
+    private SampleFragmentDispatcher dispatcher = new SampleFragmentDispatcher();
+
+    @Test
+    public void bindOnlyOnceWhenReAttached() {
+        dispatcher.onAttach(fragment, activity);
+        dispatcher.onAttach(fragment, activity);
+
+        assertThat(dispatcher.bindCount).is(1);
+    }
+}

--- a/lightcycle-integration-test/src/test/java/com/soundcloud/lightcycle/integration_test/SampleSupportFragmentDispatcherTest.java
+++ b/lightcycle-integration-test/src/test/java/com/soundcloud/lightcycle/integration_test/SampleSupportFragmentDispatcherTest.java
@@ -1,0 +1,28 @@
+package com.soundcloud.lightcycle.integration_test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.soundcloud.lightcycle.sample.basic.BuildConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import android.app.Activity;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 22)
+public class SampleSupportFragmentDispatcherTest {
+    private SampleSupportFragment fragment = new SampleSupportFragment();
+    private Activity activity = new SampleAppCompatActivity();
+
+    private SampleSupportFragmentDispatcher dispatcher = new SampleSupportFragmentDispatcher();
+
+    @Test
+    public void bindOnlyOnceWhenReAttached() {
+        dispatcher.onAttach(fragment, activity);
+        dispatcher.onAttach(fragment, activity);
+
+        assertThat(dispatcher.bindCount).is(1);
+    }
+}

--- a/lightcycle-integration-test/src/test/java/com/soundcloud/lightcycle/integration_test/SupportFragmentLoggerTest.java
+++ b/lightcycle-integration-test/src/test/java/com/soundcloud/lightcycle/integration_test/SupportFragmentLoggerTest.java
@@ -1,19 +1,19 @@
 package com.soundcloud.lightcycle.integration_test;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.truth.BooleanSubject;
 import com.soundcloud.lightcycle.integration_test.callback.FragmentLifecycleCallback;
 import com.soundcloud.lightcycle.sample.basic.BuildConfig;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.support.v4.SupportFragmentController;
+import utils.FragmentTestHelper;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 22)
@@ -105,6 +105,18 @@ public class SupportFragmentLoggerTest {
                         FragmentLifecycleCallback.onDestroy,
                         FragmentLifecycleCallback.onDetach)
         );
+    }
+
+    @Test
+    public void bindFragmentOnlyOnceWhenReAttached() {
+        FragmentTestHelper
+                .from(sampleSupportFragment)
+                .addFragment()
+                .removeFragment()
+                .addFragment();
+
+        assertThat(sampleSupportFragment.onAttachCount).is(2);
+        assertThat(sampleSupportFragment.bindCount).is(1);
     }
 
     private void assertLifecycleCallbackCallIsCorrect(List<FragmentLifecycleCallback> callbacks) {

--- a/lightcycle-integration-test/src/test/java/utils/FragmentTestHelper.java
+++ b/lightcycle-integration-test/src/test/java/utils/FragmentTestHelper.java
@@ -1,0 +1,118 @@
+package utils;
+
+import org.robolectric.Robolectric;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.widget.LinearLayout;
+
+public abstract class FragmentTestHelper {
+    public abstract FragmentTestHelper removeFragment();
+
+    public abstract FragmentTestHelper addFragment();
+
+    public static FragmentTestHelper from(android.support.v4.app.Fragment fragment) {
+        return SupportFragmentTestHelper.create(fragment);
+    }
+
+    public static FragmentTestHelper from(Fragment fragment) {
+        return MyFragmentTestHelper.create(fragment);
+    }
+
+    private static final class SupportFragmentTestHelper extends FragmentTestHelper {
+
+        private final android.support.v4.app.FragmentManager fragmentManager;
+        private final android.support.v4.app.Fragment fragment;
+
+        SupportFragmentTestHelper(FragmentManager fragmentManager, android.support.v4.app.Fragment fragment) {
+            this.fragmentManager = fragmentManager;
+            this.fragment = fragment;
+        }
+
+        static SupportFragmentTestHelper create(android.support.v4.app.Fragment fragment) {
+            return new SupportFragmentTestHelper(Robolectric.buildActivity(SupportFragmentControllerActivity.class)
+                                                            .create()
+                                                            .get()
+                                                            .getSupportFragmentManager(),
+                                                 fragment);
+        }
+
+        @Override
+        public FragmentTestHelper removeFragment() {
+            fragmentManager
+                    .beginTransaction()
+                    .remove(fragment)
+                    .commit();
+            return this;
+        }
+
+        @Override
+        public FragmentTestHelper addFragment() {
+            fragmentManager
+                    .beginTransaction().add(1, fragment)
+                    .commit();
+            return this;
+        }
+
+        static class SupportFragmentControllerActivity extends FragmentActivity {
+            @Override
+            protected void onCreate(Bundle savedInstanceState) {
+                super.onCreate(savedInstanceState);
+                LinearLayout view = new LinearLayout(this);
+                view.setId(1);
+
+                setContentView(view);
+            }
+        }
+    }
+
+    private static final class MyFragmentTestHelper extends FragmentTestHelper {
+
+        private final android.app.FragmentManager fragmentManager;
+        private final android.app.Fragment fragment;
+
+        MyFragmentTestHelper(android.app.FragmentManager fragmentManager, Fragment fragment) {
+            this.fragmentManager = fragmentManager;
+            this.fragment = fragment;
+        }
+
+        static MyFragmentTestHelper create(android.app.Fragment fragment) {
+            return new MyFragmentTestHelper(Robolectric.buildActivity(FragmentControllerActivity.class)
+                                                       .create()
+                                                       .get()
+                                                       .getFragmentManager(),
+                                            fragment);
+        }
+
+        @Override
+        public FragmentTestHelper removeFragment() {
+            fragmentManager
+                    .beginTransaction()
+                    .remove(fragment)
+                    .commit();
+            return this;
+        }
+
+        @Override
+        public FragmentTestHelper addFragment() {
+            fragmentManager
+                    .beginTransaction().add(1, fragment)
+                    .commit();
+            return this;
+        }
+
+        public static class FragmentControllerActivity extends Activity {
+            @Override
+            protected void onCreate(Bundle savedInstanceState) {
+                super.onCreate(savedInstanceState);
+                LinearLayout view = new LinearLayout(this);
+                view.setId(1);
+
+                setContentView(view);
+            }
+        }
+    }
+}

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
@@ -18,7 +18,9 @@ import java.util.Set;
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public class FragmentLightCycleDispatcher<T extends Fragment>
         implements LightCycleDispatcher<FragmentLightCycle<T>>, FragmentLightCycle<T> {
+
     private final Set<FragmentLightCycle<T>> fragmentLightCycles;
+    private boolean bound;
 
     public FragmentLightCycleDispatcher() {
         this.fragmentLightCycles = new HashSet<>();
@@ -32,7 +34,7 @@ public class FragmentLightCycleDispatcher<T extends Fragment>
 
     @Override
     public void onAttach(T fragment, Activity activity) {
-        LightCycles.bind(this);
+        bindIfNecessary();
         for (FragmentLightCycle<T> component : fragmentLightCycles) {
             component.onAttach(fragment, activity);
         }
@@ -40,9 +42,16 @@ public class FragmentLightCycleDispatcher<T extends Fragment>
 
     @Override
     public void onAttach(T fragment, Context context) {
-        LightCycles.bind(this);
+        bindIfNecessary();
         for (FragmentLightCycle<T> component : fragmentLightCycles) {
             component.onAttach(fragment, context);
+        }
+    }
+
+    private void bindIfNecessary() {
+        if (!bound) {
+            LightCycles.bind(this);
+            bound = true;
         }
     }
 

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/FragmentLightCycleDispatcher.java
@@ -1,5 +1,6 @@
 package com.soundcloud.lightcycle;
 
+import com.soundcloud.lightcycle.util.LightCycleBinderHelper;
 import com.soundcloud.lightcycle.util.Preconditions;
 
 import android.annotation.TargetApi;
@@ -20,10 +21,11 @@ public class FragmentLightCycleDispatcher<T extends Fragment>
         implements LightCycleDispatcher<FragmentLightCycle<T>>, FragmentLightCycle<T> {
 
     private final Set<FragmentLightCycle<T>> fragmentLightCycles;
-    private boolean bound;
+    private final LightCycleBinderHelper binderHelper;
 
     public FragmentLightCycleDispatcher() {
         this.fragmentLightCycles = new HashSet<>();
+        this.binderHelper = new LightCycleBinderHelper(this);
     }
 
     @Override
@@ -34,7 +36,7 @@ public class FragmentLightCycleDispatcher<T extends Fragment>
 
     @Override
     public void onAttach(T fragment, Activity activity) {
-        bindIfNecessary();
+        binderHelper.bindIfNecessary();
         for (FragmentLightCycle<T> component : fragmentLightCycles) {
             component.onAttach(fragment, activity);
         }
@@ -42,16 +44,9 @@ public class FragmentLightCycleDispatcher<T extends Fragment>
 
     @Override
     public void onAttach(T fragment, Context context) {
-        bindIfNecessary();
+        binderHelper.bindIfNecessary();
         for (FragmentLightCycle<T> component : fragmentLightCycles) {
             component.onAttach(fragment, context);
-        }
-    }
-
-    private void bindIfNecessary() {
-        if (!bound) {
-            LightCycles.bind(this);
-            bound = true;
         }
     }
 

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleFragment.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleFragment.java
@@ -1,5 +1,8 @@
 package com.soundcloud.lightcycle;
 
+import com.soundcloud.lightcycle.util.LightCycleBinderHelper;
+import com.soundcloud.lightcycle.util.Preconditions;
+
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
@@ -9,16 +12,15 @@ import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
 
-import com.soundcloud.lightcycle.util.Preconditions;
-
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public abstract class LightCycleFragment<FragmentType extends Fragment> extends Fragment implements LightCycleDispatcher<FragmentLightCycle<FragmentType>> {
 
     private final FragmentLightCycleDispatcher<FragmentType> lifeCycleDispatcher;
-    private boolean bound;
+    private final LightCycleBinderHelper binderHelper;
 
     public LightCycleFragment() {
-        lifeCycleDispatcher = new FragmentLightCycleDispatcher<>();
+        this.lifeCycleDispatcher = new FragmentLightCycleDispatcher<>();
+        this.binderHelper = new LightCycleBinderHelper(this);
     }
 
     @Override
@@ -31,7 +33,7 @@ public abstract class LightCycleFragment<FragmentType extends Fragment> extends 
     @TargetApi(23)
     public void onAttach(Context context) {
         super.onAttach(context);
-        bindIfNecessary();
+        binderHelper.bindIfNecessary();
         lifeCycleDispatcher.onAttach(fragment(), context);
     }
 
@@ -43,15 +45,8 @@ public abstract class LightCycleFragment<FragmentType extends Fragment> extends 
     @SuppressWarnings("deprecation")
     public void onAttach(Activity activity) {
         super.onAttach(activity);
-        bindIfNecessary();
+        binderHelper.bindIfNecessary();
         lifeCycleDispatcher.onAttach(fragment(), activity);
-    }
-
-    private void bindIfNecessary() {
-        if (!bound) {
-            LightCycles.bind(this);
-            bound = true;
-        }
     }
 
     @Override

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCyclePreferenceFragmentCompat.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCyclePreferenceFragmentCompat.java
@@ -1,5 +1,8 @@
 package com.soundcloud.lightcycle;
 
+import com.soundcloud.lightcycle.util.LightCycleBinderHelper;
+import com.soundcloud.lightcycle.util.Preconditions;
+
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -7,16 +10,15 @@ import android.support.v7.preference.PreferenceFragmentCompat;
 import android.view.MenuItem;
 import android.view.View;
 
-import com.soundcloud.lightcycle.util.Preconditions;
-
 public abstract class LightCyclePreferenceFragmentCompat<FragmentType extends Fragment>
         extends PreferenceFragmentCompat implements LightCycleDispatcher<SupportFragmentLightCycle<FragmentType>> {
 
     private final SupportFragmentLightCycleDispatcher<FragmentType> lifeCycleDispatcher;
-    private boolean bound;
+    private final LightCycleBinderHelper binderHelper;
 
     public LightCyclePreferenceFragmentCompat() {
-        lifeCycleDispatcher = new SupportFragmentLightCycleDispatcher<>();
+        this.lifeCycleDispatcher = new SupportFragmentLightCycleDispatcher<>();
+        this.binderHelper = new LightCycleBinderHelper(this);
     }
 
     @Override
@@ -28,15 +30,8 @@ public abstract class LightCyclePreferenceFragmentCompat<FragmentType extends Fr
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
-        bindIfNecessary();
+        binderHelper.bindIfNecessary();
         lifeCycleDispatcher.onAttach(fragment(), activity);
-    }
-
-    private void bindIfNecessary() {
-        if (!bound) {
-            LightCycles.bind(this);
-            bound = true;
-        }
     }
 
     @Override

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleSupportDialogFragment.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleSupportDialogFragment.java
@@ -1,5 +1,8 @@
 package com.soundcloud.lightcycle;
 
+import com.soundcloud.lightcycle.util.LightCycleBinderHelper;
+import com.soundcloud.lightcycle.util.Preconditions;
+
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
@@ -7,16 +10,15 @@ import android.support.v4.app.Fragment;
 import android.view.MenuItem;
 import android.view.View;
 
-import com.soundcloud.lightcycle.util.Preconditions;
-
 public abstract class LightCycleSupportDialogFragment<FragmentType extends Fragment>
         extends DialogFragment implements LightCycleDispatcher<SupportFragmentLightCycle<FragmentType>> {
 
     private final SupportFragmentLightCycleDispatcher<FragmentType> lifeCycleDispatcher;
-    private boolean bound;
+    private final LightCycleBinderHelper binderHelper;
 
     public LightCycleSupportDialogFragment() {
-        lifeCycleDispatcher = new SupportFragmentLightCycleDispatcher<>();
+        this.lifeCycleDispatcher = new SupportFragmentLightCycleDispatcher<>();
+        this.binderHelper = new LightCycleBinderHelper(this);
     }
 
     @Override
@@ -28,15 +30,8 @@ public abstract class LightCycleSupportDialogFragment<FragmentType extends Fragm
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
-        bindIfNecessary();
+        binderHelper.bindIfNecessary();
         lifeCycleDispatcher.onAttach(fragment(), activity);
-    }
-
-    private void bindIfNecessary() {
-        if (!bound) {
-            LightCycles.bind(this);
-            bound = true;
-        }
     }
 
     @Override

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleSupportFragment.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/LightCycleSupportFragment.java
@@ -1,20 +1,22 @@
 package com.soundcloud.lightcycle;
 
+import com.soundcloud.lightcycle.util.LightCycleBinderHelper;
+import com.soundcloud.lightcycle.util.Preconditions;
+
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.MenuItem;
 import android.view.View;
 
-import com.soundcloud.lightcycle.util.Preconditions;
-
 public abstract class LightCycleSupportFragment<FragmentType extends Fragment> extends Fragment implements LightCycleDispatcher<SupportFragmentLightCycle<FragmentType>> {
 
     private final SupportFragmentLightCycleDispatcher<FragmentType> lifeCycleDispatcher;
-    private boolean bound;
+    private final LightCycleBinderHelper binderHelper;
 
     public LightCycleSupportFragment() {
-        lifeCycleDispatcher = new SupportFragmentLightCycleDispatcher<>();
+        this.lifeCycleDispatcher = new SupportFragmentLightCycleDispatcher<>();
+        this.binderHelper = new LightCycleBinderHelper(this);
     }
 
     @Override
@@ -26,15 +28,8 @@ public abstract class LightCycleSupportFragment<FragmentType extends Fragment> e
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
-        bindIfNecessary();
+        binderHelper.bindIfNecessary();
         lifeCycleDispatcher.onAttach(fragment(), activity);
-    }
-
-    private void bindIfNecessary() {
-        if (!bound) {
-            LightCycles.bind(this);
-            bound = true;
-        }
     }
 
     @Override

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/SupportFragmentLightCycleDispatcher.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/SupportFragmentLightCycleDispatcher.java
@@ -14,7 +14,9 @@ import java.util.Set;
 
 public class SupportFragmentLightCycleDispatcher<T extends Fragment>
         implements LightCycleDispatcher<SupportFragmentLightCycle<T>>, SupportFragmentLightCycle<T> {
+
     private final Set<SupportFragmentLightCycle<T>> fragmentLightCycles;
+    private boolean bound;
 
     public SupportFragmentLightCycleDispatcher() {
         this.fragmentLightCycles = new HashSet<>();
@@ -28,9 +30,16 @@ public class SupportFragmentLightCycleDispatcher<T extends Fragment>
 
     @Override
     public void onAttach(T fragment, Activity activity) {
-        LightCycles.bind(this);
+        bindIfNecessary();
         for (SupportFragmentLightCycle<T> component : fragmentLightCycles) {
             component.onAttach(fragment, activity);
+        }
+    }
+
+    private void bindIfNecessary() {
+        if (!bound) {
+            LightCycles.bind(this);
+            bound = true;
         }
     }
 

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/SupportFragmentLightCycleDispatcher.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/SupportFragmentLightCycleDispatcher.java
@@ -1,5 +1,6 @@
 package com.soundcloud.lightcycle;
 
+import com.soundcloud.lightcycle.util.LightCycleBinderHelper;
 import com.soundcloud.lightcycle.util.Preconditions;
 
 import android.app.Activity;
@@ -16,10 +17,11 @@ public class SupportFragmentLightCycleDispatcher<T extends Fragment>
         implements LightCycleDispatcher<SupportFragmentLightCycle<T>>, SupportFragmentLightCycle<T> {
 
     private final Set<SupportFragmentLightCycle<T>> fragmentLightCycles;
-    private boolean bound;
+    private final LightCycleBinderHelper binderHelper;
 
     public SupportFragmentLightCycleDispatcher() {
         this.fragmentLightCycles = new HashSet<>();
+        this.binderHelper = new LightCycleBinderHelper(this);
     }
 
     @Override
@@ -30,16 +32,9 @@ public class SupportFragmentLightCycleDispatcher<T extends Fragment>
 
     @Override
     public void onAttach(T fragment, Activity activity) {
-        bindIfNecessary();
+        binderHelper.bindIfNecessary();
         for (SupportFragmentLightCycle<T> component : fragmentLightCycles) {
             component.onAttach(fragment, activity);
-        }
-    }
-
-    private void bindIfNecessary() {
-        if (!bound) {
-            LightCycles.bind(this);
-            bound = true;
         }
     }
 

--- a/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/util/LightCycleBinderHelper.java
+++ b/lightcycle-lib/src/main/java/com/soundcloud/lightcycle/util/LightCycleBinderHelper.java
@@ -1,0 +1,21 @@
+package com.soundcloud.lightcycle.util;
+
+import com.soundcloud.lightcycle.LightCycleDispatcher;
+import com.soundcloud.lightcycle.LightCycles;
+
+public class LightCycleBinderHelper {
+
+    private final LightCycleDispatcher<?> dispatcher;
+    private boolean isBound = false;
+
+    public LightCycleBinderHelper(LightCycleDispatcher<?> dispatcher) {
+        this.dispatcher = dispatcher;
+    }
+
+    public void bindIfNecessary() {
+        if (!isBound) {
+            LightCycles.bind(dispatcher);
+            isBound = true;
+        }
+    }
+}


### PR DESCRIPTION
# Scope 

- Fix auto-binding issue in Fragments for 1.5.0. Fragment should not try to bind again when `onAttach` is called again. 
- Lifted lightcyles of the same lightcycle should be equal to enable the dispatchers to dedup. 