### PR TITLE
Tweak proguard config

### DIFF
--- a/lightcycle-lib/proguard-rules.txt
+++ b/lightcycle-lib/proguard-rules.txt
@@ -1,6 +1,4 @@
--keep class com.soundcloud.** { *; }
-
 -keep class com.soundcloud.lightcycle.** { *; }
 -dontwarn com.soundcloud.lightcycle.**
 -keep class **$LightCycleBinder { *; }
-
+-keep class * implements com.soundcloud.lightcycle.LightCycleDispatcher`


### PR DESCRIPTION
See https://github.com/soundcloud/lightcycle/issues/95

- We don't need to keep the `com.soundcloud.**` package
- We need to keep the class names for classes implementing the `LightCycleDispatcher` interface