### PR TITLE
Add basic Cirrus CI configuration

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,10 @@
+task:
+  name: Check
+  container:
+    image: cirrusci/android-sdk:27
+  check_script: ./gradlew check
+  always:
+    junit_result_artifacts:
+      path: "**/test-results/**/*.xml"
+      format: junit
+      type: text/xml


### PR DESCRIPTION
The goal is to have a basic CI integration to run unit tests and lint.